### PR TITLE
Support for express middlewares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.6.tgz",
       "integrity": "sha512-B7sY963pBsP46QG/yTX8ei2R8zIUDQUOhPZjTBWBGQXcBMLGFKHc0R8DWkAmouGmval5sDSuQA3AB2C9VmHw6A==",
       "requires": {
-        "@types/express": "4.0.38",
-        "@types/node": "8.0.47"
+        "@types/express": "*",
+        "@types/node": "*"
       }
     },
     "@types/express": {
@@ -18,9 +18,9 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.38.tgz",
       "integrity": "sha512-1HfDZFzzmcusHNTl/hRhrLIoVGZt3yqJVIZtMaQm/K14naptdjU9fEeXl1gCDzE2E9BqnoL6B5oidi7da3etbQ==",
       "requires": {
-        "@types/body-parser": "1.16.6",
-        "@types/express-serve-static-core": "4.0.54",
-        "@types/serve-static": "1.13.0"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -28,7 +28,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.54.tgz",
       "integrity": "sha512-SAwkKnz0z3VcUyT3eiZRM2pDiZ4i2xhOXHTZHdoXu6UCC1o33lnzJMftXCYTRmLvFOUxryov8c9E0JLlY2ylNw==",
       "requires": {
-        "@types/node": "8.0.47"
+        "@types/node": "*"
       }
     },
     "@types/mime": {
@@ -46,14 +46,20 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.0.tgz",
       "integrity": "sha512-wvQkePwCDZoyQPGb64DTl2TEeLw54CQFXjY+tznxYYxNcBb4LG40ezoVbMDa0epwE4yogB0f42jCaH0356x5Mg==",
       "requires": {
-        "@types/express-serve-static-core": "4.0.54",
-        "@types/mime": "2.0.0"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "restyped": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/restyped/-/restyped-1.1.0.tgz",
       "integrity": "sha512-Q5rxwCnw0AR4/8I7YOxE0/ElyHcB86UtV4U0RnyxXY/s8EDwd1AZGTXxrKQUAdVbPljlNsz4VXXq6oT5HnnxPw=="
+    },
+    "typescript": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "dependencies": {
     "@types/express": "4.0.38",
     "restyped": "1.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^3.0.3"
   }
 }


### PR DESCRIPTION
So that one e.g. can write:
```
function firstMiddleware(req, res, next) {}
function secondMiddleware(req, res, next) {}

router.get(
    '/permissions',
    (req, res) => {
        return Promise.resolve().then(() => {
            return {
                managers: ['someone', 'another']
            };
        });
    },
    firstMiddleware, secondMiddleware
);
```

The router method call signature is backwards compatible but slightly unfortunately the middlewares need to be appended instead of prepended. 
Experimented with a single array of handlers but that did not turn out so well:
* union objects in the array are not callable unless their call signature is identical https://github.com/Microsoft/TypeScript/issues/7294
* if call signatures are identical, TypeScript won't differentiate the two on return value (since `Handler` has `void`), a faulty `TypedHandler` is hence interpreted as a Handler and no errors are generated